### PR TITLE
[codex] Update Dalamud API 15 release

### DIFF
--- a/JobPlaytimeTracker.json
+++ b/JobPlaytimeTracker.json
@@ -3,17 +3,17 @@
     "Author": "Zuiko",
     "Name": "FFXIV Job Playtime Tracker",
     "InternalName": "JobPlaytimeTracker",
-    "AssemblyVersion": "1.0.9353.0",
+    "AssemblyVersion": "1.0.9354.0",
     "Description": "Tracks metrics job-by-job. Show window with /jobplaytimetracker.",
     "ApplicableVersion": "any",
-    "DalamudApiLevel": 13,
+    "DalamudApiLevel": 15,
     "LoadRequiredState": 0,
     "LoadSync": false,
     "CanUnloadAsync": false,
     "LoadPriority": 0,
     "Punchline": "Tracks metrics job-by-job. Show window with /jobplaytimetracker.",
-    "DownloadLinkInstall": "https://github.com/markaperkins/FFXIVJobTimePlugin/releases/download/Beta-0.0.0.10/FFXIVJobPlaytimePlugin-Beta-0.0.0.10.zip",
-    "DownloadLinkUpdate": "https://github.com/markaperkins/FFXIVJobTimePlugin/releases/download/Beta-0.0.0.10/FFXIVJobPlaytimePlugin-Beta-0.0.0.10.zip",
+    "DownloadLinkInstall": "https://github.com/markaperkins/FFXIVJobTimePlugin/releases/download/Beta-0.0.0.11/FFXIVJobPlaytimePlugin-Beta-0.0.0.11.zip",
+    "DownloadLinkUpdate": "https://github.com/markaperkins/FFXIVJobTimePlugin/releases/download/Beta-0.0.0.11/FFXIVJobPlaytimePlugin-Beta-0.0.0.11.zip",
     "AcceptsFeedback": true
   }
 ]

--- a/JobPlaytimeTracker/JobPlaytimeTracker.csproj
+++ b/JobPlaytimeTracker/JobPlaytimeTracker.csproj
@@ -1,12 +1,12 @@
-<Project Sdk="Dalamud.NET.Sdk/13.0.0">
+<Project Sdk="Dalamud.NET.Sdk/15.0.0">
     <PropertyGroup>
-        <TargetFramework>net9.0-windows7.0</TargetFramework>
+        <TargetFramework>net10.0-windows</TargetFramework>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <LangVersion>latest</LangVersion>
 
-        <Version>1.0.9353.0</Version>
+        <Version>1.0.9354.0</Version>
         <Description>A sample plugin.</Description>
         <PackageProjectUrl>https://github.com/goatcorp/SamplePlugin</PackageProjectUrl>
         <PackageLicenseExpression>GPL-3.0</PackageLicenseExpression>
@@ -38,10 +38,5 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.8" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <PackageReference Include="DalamudPackager" Version="13.*" PrivateAssets="all" />
-        <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="all" />
     </ItemGroup>
 </Project>

--- a/JobPlaytimeTracker/JobPlaytimeTracker.json
+++ b/JobPlaytimeTracker/JobPlaytimeTracker.json
@@ -1,20 +1,20 @@
 {
-    "Author": "your name here",
-    "Name": "Sample Plugin",
+    "Author": "Zuiko",
+    "Name": "FFXIV Job Playtime Tracker",
     "InternalName": "JobPlaytimeTracker",
-    "AssemblyVersion": "1.0.9353.0",
-    "Description": "A description that shows up in /xlplugins. List any major slash-command(s).",
+    "AssemblyVersion": "1.0.9354.0",
+    "Description": "Tracks metrics job-by-job. Show window with /jobplaytimetracker.",
     "ApplicableVersion": "any",
     "Tags": [
-        "sample",
-        "plugin",
-        "goats"
+        "job",
+        "playtime",
+        "tracker"
     ],
-    "DalamudApiLevel": 13,
+    "DalamudApiLevel": 15,
     "LoadRequiredState": 0,
     "LoadSync": false,
     "CanUnloadAsync": false,
     "LoadPriority": 0,
-    "Punchline": "A short one-liner that shows up in /xlplugins.",
+    "Punchline": "Tracks metrics job-by-job. Show window with /jobplaytimetracker.",
     "AcceptsFeedback": true
 }

--- a/JobPlaytimeTracker/JobPlaytimeTracker/Commands/DisplayConfigurationWindow.cs
+++ b/JobPlaytimeTracker/JobPlaytimeTracker/Commands/DisplayConfigurationWindow.cs
@@ -1,4 +1,3 @@
-using Dalamud.Interface.Windowing;
 using JobPlaytimeTracker.JobPlaytimeTracker.DataStructures.Context;
 using JobPlaytimeTracker.JobPlaytimeTracker.Windows;
 using JobPlaytimeTracker.Legos.Abstractions;
@@ -18,8 +17,7 @@ namespace JobPlaytimeTracker.JobPlaytimeTracker.Commands
 
         public override void OnExecuteHandler(string command, string args)
         {
-            Window? configWindow = _context.PluginWindows!.Windows.Where(window => window.GetType() == typeof(ConfigurationScreen))
-                                                                                          .FirstOrDefault();
+            ConfigurationScreen? configWindow = _context.PluginWindows!.Windows.OfType<ConfigurationScreen>().FirstOrDefault();
 
             if (configWindow is not null)
             {

--- a/JobPlaytimeTracker/JobPlaytimeTracker/Commands/DisplayMainWindow.cs
+++ b/JobPlaytimeTracker/JobPlaytimeTracker/Commands/DisplayMainWindow.cs
@@ -1,4 +1,3 @@
-using Dalamud.Interface.Windowing;
 using JobPlaytimeTracker.JobPlaytimeTracker.DataStructures.Context;
 using JobPlaytimeTracker.JobPlaytimeTracker.Windows;
 using JobPlaytimeTracker.Legos.Abstractions;
@@ -17,8 +16,7 @@ namespace JobPlaytimeTracker.JobPlaytimeTracker.Commands
 
         public override void OnExecuteHandler(string command, string args)
         {
-            Window? mainWindow = _context.PluginWindows!.Windows.Where(window => window.GetType() == typeof(MainScreen))
-                                                                                       .FirstOrDefault();
+            MainScreen? mainWindow = _context.PluginWindows!.Windows.OfType<MainScreen>().FirstOrDefault();
 
             if (mainWindow is not null)
             {

--- a/JobPlaytimeTracker/JobPlaytimeTracker/DataStructures/Context/PluginContext.cs
+++ b/JobPlaytimeTracker/JobPlaytimeTracker/DataStructures/Context/PluginContext.cs
@@ -25,6 +25,8 @@ namespace JobPlaytimeTracker.JobPlaytimeTracker.DataStructures.Context
         public ITextureProvider TextureProvider { get; private set; }
         public ICommandManager CommandManager { get; private set; }
         public IClientState ClientState { get; private set; }
+        public IPlayerState PlayerState { get; private set; }
+        public IObjectTable ObjectTable { get; private set; }
         public IDataManager DataManager { get; private set; }
         public IPluginLog Log { get; private set; }
         public IChatGui ChatGUI { get; private set; }
@@ -40,6 +42,8 @@ namespace JobPlaytimeTracker.JobPlaytimeTracker.DataStructures.Context
                              ITextureProvider textureProvider,
                              ICommandManager commandManager,
                              IClientState clientState,
+                             IPlayerState playerState,
+                             IObjectTable objectTable,
                              IDataManager dataManager,
                              IPluginLog log,
                              IChatGui chatGUI,
@@ -52,6 +56,8 @@ namespace JobPlaytimeTracker.JobPlaytimeTracker.DataStructures.Context
             TextureProvider = textureProvider;
             CommandManager = commandManager;
             ClientState = clientState;
+            PlayerState = playerState;
+            ObjectTable = objectTable;
             DataManager = dataManager;
             Log = log;
             ChatGUI = chatGUI;
@@ -121,7 +127,7 @@ namespace JobPlaytimeTracker.JobPlaytimeTracker.DataStructures.Context
         public void UpdatePlayer()
         {
             // Load current player's metrics
-            string playerName = ClientState.LocalPlayer?.Name.ToString() ?? "Unknown";
+            string playerName = PlayerState.IsLoaded ? PlayerState.CharacterName.ToString() : "Unknown";
             Player loadedPlayer = Player.LoadPlayer(this, playerName);
 
             // Save previous metrics
@@ -133,7 +139,7 @@ namespace JobPlaytimeTracker.JobPlaytimeTracker.DataStructures.Context
 
         public bool IsPlayerDiscipleOfHand()
         {
-            if (ClientState.LocalPlayer == null) return false;
+            if (PlayerState.IsLoaded == false) return false;
 
             var craftingJobs = new HashSet<FFXIVJob>
             {
@@ -146,12 +152,12 @@ namespace JobPlaytimeTracker.JobPlaytimeTracker.DataStructures.Context
                 FFXIVJob.Alchemist,
                 FFXIVJob.Culinarian
             };
-            return craftingJobs.Contains((FFXIVJob)ClientState.LocalPlayer.ClassJob.RowId);
+            return craftingJobs.Contains((FFXIVJob)PlayerState.ClassJob.RowId);
         }
 
         public bool IsPlayerDiscipleOfLand()
         {
-            if (ClientState.LocalPlayer == null) return false;
+            if (PlayerState.IsLoaded == false) return false;
 
             var gatheringJobs = new HashSet<FFXIVJob>
             {
@@ -159,7 +165,7 @@ namespace JobPlaytimeTracker.JobPlaytimeTracker.DataStructures.Context
                 FFXIVJob.Botanist,
                 FFXIVJob.Fisher
             };
-            return gatheringJobs.Contains((FFXIVJob)ClientState.LocalPlayer.ClassJob.RowId);
+            return gatheringJobs.Contains((FFXIVJob)PlayerState.ClassJob.RowId);
         }
 
         public bool IsPlayerDiscipleOfWarMagic()

--- a/JobPlaytimeTracker/JobPlaytimeTracker/DataStructures/Entities/Player.cs
+++ b/JobPlaytimeTracker/JobPlaytimeTracker/DataStructures/Entities/Player.cs
@@ -157,7 +157,7 @@ namespace JobPlaytimeTracker.JobPlaytimeTracker.DataStructures.Entities
             // Save the player's current time before it is erased
             if(currentContext.CurrentPlayer is not null)
             {
-                bool evalResult_IsStatusAFK = currentContext.ClientState.LocalPlayer.OnlineStatus.Value.Name.ToString().Equals("Away from Keyboard");
+                bool evalResult_IsStatusAFK = currentContext.ObjectTable.LocalPlayer?.OnlineStatus.Value.Name.ToString().Equals("Away from Keyboard") ?? false;
 
                 TimeSpan elapsedTime = currentContext.ReceivedUpdate();
                 if (evalResult_IsStatusAFK == true)

--- a/JobPlaytimeTracker/JobPlaytimeTracker/EventHandlers/ClientStateEvent.cs
+++ b/JobPlaytimeTracker/JobPlaytimeTracker/EventHandlers/ClientStateEvent.cs
@@ -108,7 +108,7 @@ namespace JobPlaytimeTracker.JobPlaytimeTracker.EventHandlers
 
         public void OnTick(IFramework framework)
         {
-            IPlayerCharacter? currentPlayer = _context.ClientState.LocalPlayer;
+            IPlayerCharacter? currentPlayer = _context.ObjectTable.LocalPlayer;
             if (currentPlayer is null) return; // Player is not logged in
 
             CheckOnlineStatus(currentPlayer.OnlineStatus.Value.Name.ToString());
@@ -159,7 +159,8 @@ namespace JobPlaytimeTracker.JobPlaytimeTracker.EventHandlers
         private void RegisterPlayerDeath()
         {
             // Gate function to return if this function is somehow called while LocalPlayer is null (logged out)
-            if (_context.ClientState.LocalPlayer is null) return;
+            IPlayerCharacter? currentPlayer = _context.ObjectTable.LocalPlayer;
+            if (currentPlayer is null) return;
 
             // Gate function to return if this function is somehow called while CurrentPlayer is null
             if (_context.CurrentPlayer is null) return;
@@ -168,7 +169,7 @@ namespace JobPlaytimeTracker.JobPlaytimeTracker.EventHandlers
             // function call, and is unset on the first tick when the player is no longer dead.
             if (EventStates.HasFlag(EventStateFlags.PlayerIsRIP)) return;
 
-            _context.CurrentPlayer.AddDeath((FFXIVJob)_context.ClientState.LocalPlayer.ClassJob.RowId);
+            _context.CurrentPlayer.AddDeath((FFXIVJob)currentPlayer.ClassJob.RowId);
         }
     }
 }

--- a/JobPlaytimeTracker/JobPlaytimeTracker/EventHandlers/ServerBarEvent.cs
+++ b/JobPlaytimeTracker/JobPlaytimeTracker/EventHandlers/ServerBarEvent.cs
@@ -36,16 +36,13 @@ namespace JobPlaytimeTracker.JobPlaytimeTracker.EventHandlers
         private void OnClick()
         {
             // Attempt to find reference to main window
-            Window? mainWindow = _context.PluginWindows!.Windows.Where(window => window.GetType() == typeof(MainScreen))
-                                                                .FirstOrDefault();
+            MainScreen? mainWindow = _context.PluginWindows!.Windows.OfType<MainScreen>().FirstOrDefault();
 
             // If reference is found, set the current selected job and then toggle window to display
             if (mainWindow is not null)
             {
-                MainScreen windowAsMainScreen = (MainScreen)mainWindow;
-
-                windowAsMainScreen.CurrentSelectedJobIndex = (int)_context.CurrentJob;
-                windowAsMainScreen.Toggle();
+                mainWindow.CurrentSelectedJobIndex = (int)_context.CurrentJob;
+                mainWindow.Toggle();
             }
         }
     }

--- a/JobPlaytimeTracker/JobPlaytimeTrackerPlugin.cs
+++ b/JobPlaytimeTracker/JobPlaytimeTrackerPlugin.cs
@@ -45,6 +45,8 @@ namespace JobPlaytimeTracker
         [PluginService] public static ITextureProvider TextureProvider { get; private set; } = null!;
         [PluginService] public static ICommandManager CommandManager { get; private set; } = null!;
         [PluginService] public static IClientState ClientState { get; private set; } = null!;
+        [PluginService] public static IPlayerState PlayerState { get; private set; } = null!;
+        [PluginService] public static IObjectTable ObjectTable { get; private set; } = null!;
         [PluginService] public static IDataManager DataManager { get; private set; } = null!;
         [PluginService] public static IPluginLog Log { get; private set; } = null!;
         [PluginService] public static IChatGui ChatGui { get; private set; } = null!;
@@ -72,6 +74,8 @@ namespace JobPlaytimeTracker
                                         TextureProvider,
                                         CommandManager,
                                         ClientState,
+                                        PlayerState,
+                                        ObjectTable,
                                         DataManager,
                                         Log,
                                         ChatGui,
@@ -109,14 +113,15 @@ namespace JobPlaytimeTracker
         {
             if (_isInitialized == false)
             {
-                Context.UpdatePlayer(Player.LoadPlayer(Context, ClientState.LocalPlayer?.Name.ToString() ?? "Unknown"));
-                Context.UpdateCurrentJob((ClientState.LocalPlayer is not null) ? (FFXIVJob)(ClientState.LocalPlayer.ClassJob.RowId) : FFXIVJob.None);
+                Context.UpdatePlayer(Player.LoadPlayer(Context, PlayerState.IsLoaded ? PlayerState.CharacterName.ToString() : "Unknown"));
+                Context.UpdateCurrentJob(PlayerState.IsLoaded ? (FFXIVJob)PlayerState.ClassJob.RowId : FFXIVJob.None);
 
-                if (Context.ClientState.LocalPlayer is not null)
+                var localPlayer = Context.ObjectTable.LocalPlayer;
+                if (localPlayer is not null)
                 {
-                    if (Context.ClientState.LocalPlayer.IsDead) Context.PlayerEventHandler.EventStates |= EventStateFlags.PlayerIsRIP;
+                    if (localPlayer.IsDead) Context.PlayerEventHandler.EventStates |= EventStateFlags.PlayerIsRIP;
 
-                    if (Context.ClientState.LocalPlayer.OnlineStatus.Value.Name.Equals("AFK")) Context.PlayerEventHandler.EventStates |= EventStateFlags.PlayerIsAFK;
+                    if (localPlayer.OnlineStatus.Value.Name.Equals("AFK")) Context.PlayerEventHandler.EventStates |= EventStateFlags.PlayerIsAFK;
 
                     if (Context.Conditions[ConditionFlag.InCombat] ||
                         Context.Conditions[ConditionFlag.Crafting] ||

--- a/JobPlaytimeTracker/Legos/Abstractions/BaseWindow.cs
+++ b/JobPlaytimeTracker/Legos/Abstractions/BaseWindow.cs
@@ -5,7 +5,7 @@ using JobPlaytimeTracker.Legos.Interfaces;
 
 namespace JobPlaytimeTracker.Legos.Abstractions
 {
-    internal abstract class BaseWindow : Window, IWindow
+    internal abstract class BaseWindow : Window, Interfaces.IWindow
     {
         internal PluginContext Context { get; set; }
 

--- a/JobPlaytimeTracker/packages.lock.json
+++ b/JobPlaytimeTracker/packages.lock.json
@@ -1,18 +1,18 @@
 {
   "version": 1,
   "dependencies": {
-    "net9.0-windows7.0": {
+    "net10.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[13.0.0, )",
-        "resolved": "13.0.0",
-        "contentHash": "Mb3cUDSK/vDPQ8gQIeuCw03EMYrej1B4J44a1AvIJ9C759p9XeqdU9Hg4WgOmlnlPe0G7ILTD32PKSUpkQNa8w=="
+        "requested": "[15.0.0, )",
+        "resolved": "15.0.0",
+        "contentHash": "411vwC8/X8Z/sQ2TI6v3SvOn66xFPeOjFn3Zn+h0d3Ox2t1kFm66AhDvmx/qcMwVrR+Hidxj0dadpQ2dgyXMBQ=="
       },
       "DotNet.ReproducibleBuilds": {
         "type": "Direct",
-        "requested": "[1.2.25, )",
-        "resolved": "1.2.25",
-        "contentHash": "xCXiw7BCxHJ8pF6wPepRUddlh2dlQlbr81gXA72hdk4FLHkKXas7EH/n+fk5UCA/YfMqG1Z6XaPiUjDbUNBUzg=="
+        "requested": "[1.2.39, )",
+        "resolved": "1.2.39",
+        "contentHash": "fcFN01tDTIQqDuTwr1jUQK/geofiwjG5DycJQOnC72i1SsLAk1ELe+apBOuZ11UMQG8YKFZG1FgvjZPbqHyatg=="
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "Direct",
@@ -38,8 +38,7 @@
           "Microsoft.Extensions.DependencyModel": "9.0.8",
           "Microsoft.Extensions.Logging": "9.0.8",
           "SQLitePCLRaw.bundle_e_sqlite3": "2.1.10",
-          "SQLitePCLRaw.core": "2.1.10",
-          "System.Text.Json": "9.0.8"
+          "SQLitePCLRaw.core": "2.1.10"
         }
       },
       "Microsoft.Data.Sqlite.Core": {
@@ -82,8 +81,7 @@
           "Microsoft.Extensions.Configuration.Abstractions": "9.0.8",
           "Microsoft.Extensions.DependencyModel": "9.0.8",
           "Microsoft.Extensions.Logging": "9.0.8",
-          "SQLitePCLRaw.core": "2.1.10",
-          "System.Text.Json": "9.0.8"
+          "SQLitePCLRaw.core": "2.1.10"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {
@@ -176,10 +174,7 @@
       "SQLitePCLRaw.core": {
         "type": "Transitive",
         "resolved": "2.1.10",
-        "contentHash": "Ii8JCbC7oiVclaE/mbDEK000EFIJ+ShRPwAvvV89GOZhQ+ZLtlnSWl6ksCNMKu/VGXA4Nfi2B7LhN/QFN9oBcw==",
-        "dependencies": {
-          "System.Memory": "4.5.3"
-        }
+        "contentHash": "Ii8JCbC7oiVclaE/mbDEK000EFIJ+ShRPwAvvV89GOZhQ+ZLtlnSWl6ksCNMKu/VGXA4Nfi2B7LhN/QFN9oBcw=="
       },
       "SQLitePCLRaw.lib.e_sqlite3": {
         "type": "Transitive",
@@ -193,16 +188,6 @@
         "dependencies": {
           "SQLitePCLRaw.core": "2.1.10"
         }
-      },
-      "System.Memory": {
-        "type": "Transitive",
-        "resolved": "4.5.3",
-        "contentHash": "3oDzvc/zzetpTKWMShs1AADwZjQ/36HnsufHRPcOjyRAAMLDlu2iD33MBI2opxnezcVUtXyqDXXjoFMOU9c7SA=="
-      },
-      "System.Text.Json": {
-        "type": "Transitive",
-        "resolved": "9.0.8",
-        "contentHash": "mIQir9jBqk0V7X0Nw5hzPJZC8DuGdf+2DS3jAVsr6rq5+/VyH5rza0XGcONJUWBrZ+G6BCwNyjWYd9lncBu48A=="
       }
     }
   }


### PR DESCRIPTION
## Summary

Updates Job Playtime Tracker for FFXIV Patch 7.5 / Dalamud API 15.

- Bumps the plugin project to `Dalamud.NET.Sdk/15.0.0` and `net10.0-windows`.
- Updates the repository and packaged manifests to `DalamudApiLevel` 15 and `AssemblyVersion` 1.0.9354.0.
- Points the public repository manifest at the planned `Beta-0.0.0.11` release asset: `FFXIVJobPlaytimePlugin-Beta-0.0.0.11.zip`.
- Moves local-player access to API 15-compatible `IPlayerState` / `IObjectTable` services.
- Adjusts window lookups for the current `WindowSystem.Windows` interface return type.
- Refreshes `packages.lock.json` for the SDK-provided `DalamudPackager`/reproducible builds versions.

## Packaging

Built the Release package locally with Dalamud API 15 assemblies. The package to upload as the `Beta-0.0.0.11` release asset is:

`JobPlaytimeTracker/bin/x64/Release/FFXIVJobPlaytimePlugin-Beta-0.0.0.11.zip`

This PR is draft until that GitHub Release asset exists, because the custom repo manifest now points at that URL.

## Validation

- `DALAMUD_HOME=/mnt/c/Users/markp/AppData/Roaming/XIVLauncher/addon/Hooks/dev dotnet build JobPlaytimeTracker.sln`
- `DALAMUD_HOME=/mnt/c/Users/markp/AppData/Roaming/XIVLauncher/addon/Hooks/dev dotnet build JobPlaytimeTracker.sln -c Release`
- Inspected the generated ZIP manifest and confirmed `AssemblyVersion` 1.0.9354.0 and `DalamudApiLevel` 15.